### PR TITLE
Update VCV calculation

### DIFF
--- a/Probit-Functions.jl
+++ b/Probit-Functions.jl
@@ -59,9 +59,10 @@ end
 function vcov(obj::Optim.OptimizationResults, h!)
 	β    = obj.minimum
 	k    = length(β)
+	N    = maximum(size(X))
 	hess = zeros((k,k))
 	h!(β, hess)
-	hess \ eye(k)
+	N*(hess \ eye(k))
 end
 
 function se(obj::Optim.OptimizationResults, h!)


### PR DESCRIPTION
Edited calculation of VCV. We have the result that F^-1 = VCV and -(1/N)*\widehat H \rightarrow F. Notice the negative sign is omitted here because of minimization. What is less clear to me is that the Hessian of your objective function (the negative LL) seems like it should also have a negative sign in front of it if you want to use if it to aid search. IE, the current h! generates the correct hessian for VCV but (I think) the negative of the correct one for search.
